### PR TITLE
Bigdata 327 api swagger updates

### DIFF
--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -792,27 +792,8 @@
         "tags": [
           "Profiles"
         ],
-        "parameters": [
-          {
-            "name": "Ometria-Account-Id",
-            "in": "header",
-            "description": "Account ID to search for profile within",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "summary": "Merge profiles with duplicate email and/or id",
         "description": "Merge the profile on email and / or id",
-        "responses": {
-          "200": {
-            "description": "merge request accepted"
-          },
-          "404": {
-            "description": "The profile could not be found"
-          }
-        },
         "requestBody": {
           "required": true,
           "description": "profile to merge",
@@ -836,7 +817,15 @@
               }
             }
           }
-        }
+        },
+        "responses": {
+          "200": {
+            "description": "merge request accepted"
+          },
+          "404": {
+            "description": "The profile could not be found"
+          }
+        }        
       }
     },
     "/lists": {

--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -792,6 +792,17 @@
         "tags": [
           "Profiles"
         ],
+        "parameters": [
+          {
+            "name": "Ometria-Account-Id",
+            "in": "header",
+            "description": "Account ID to search for profile within",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "summary": "Merge profiles with duplicate email and/or id",
         "description": "Merge the profile on email and / or id",
         "responses": {

--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -23,23 +23,20 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "array",
-                "items": {
-                  "oneOf": [
-                    {
-                      "$ref": "#/components/schemas/Contact"
-                    },
-                    {
-                      "$ref": "#/components/schemas/CustomEvent"
-                    },
-                    {
-                      "$ref": "#/components/schemas/Order"
-                    },
-                    {
-                      "$ref": "#/components/schemas/Product"
-                    }
-                  ]
-                }
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/Contact"
+                  },
+                  {
+                    "$ref": "#/components/schemas/CustomEvent"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Order"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Product"
+                  }
+                ]
               }
             }
           },

--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -791,45 +791,42 @@
         }
       }
     }, "/merge-profile": {
-      "get": {
+      "post": {
         "tags": [
           "Profiles"
         ],
         "summary": "Merge profiles with duplicate email and/or id",
         "description": "Merge the profile on email and / or id",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "description": "The id of the profile to merge.",
-            "required": false,
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "name": "email_address",
-            "in": "path",
-            "description": "The email address of the profile to merge.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
         "responses": {
           "200": {
-            "description": "Profile is successfully merged",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Merge-profile"
-                }
-              }
-            }
+            "description": "merge request accepted"
           },
           "404": {
-            "description": "required either profile_id or email"
+            "description": "The profile could not be found"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "description": "profile to merge",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "description": "email of the profile required for merging"
+                  },
+                  "profile_id": {
+                    "type": "integer",
+                    "description": "the id of the profile required for merging (will match using email)"
+                  }
+                }
+              },
+              "example": {
+                "email": "example@email.com"
+              }
+            }
           }
         }
       }
@@ -3588,19 +3585,6 @@
           "timestamp": "2017-05-17 22:08:07+00",
           "reason": null,
           "reason_text": null
-        }
-      },
-      "Merge-profile": {
-        "type": "object",
-        "description": "Response from merging a profile successfully",
-        "properties": {
-          "status": {
-            "type": "string",
-            "description": "The status of the profile"
-          }
-        },
-        "example": {
-          "status": "profiles merged"
         }
       }
     }


### PR DESCRIPTION
Suggested changes as input for https://github.com/Ometria/ometria.docs.assets.external/pull/19.

@thefr0gger - after some back & forth, I think I got it:
 * The endpoint really is `/merge-profile`, not `/v2/merge-profile`, because `/v2` is part of the base URL already. So your version should be right.
 * I removed the `Ometria-Account-Id` header. It is necessary for the backend implementation, but it is generated from the `X-Ometria-Auth` header that users have to provide. So it is not part of the published interface.