### PR TITLE
Update swagger.json "includeVariants"

### DIFF
--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -142,7 +142,7 @@
           },
           {
             "name": "includeVariants",
-            "in": "path",
+            "in": "query",
             "description": "Product variants (or child products) for shippable SKUs.",
             "required": true,
             "schema": {


### PR DESCRIPTION
# Description

Changing 

"name": "includeVariants",
            "in": "**query**",
            "description": "Product variants (or child products) for shippable SKUs.",
            "required": true,
            "schema": {
              "type": "boolean"

due to validation error: 

Validation failed. /paths/products/{product_id}/get has a path parameter named "includeVariants", but there is no corresponding {includeVariants} in the path string


