### PR TITLE
BIGDATA-825 - Add publicID as a param in the result object of lists API

### DIFF
--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -1637,6 +1637,10 @@
           },
           "id": {
             "type": "string",
+            "description": "The (hashed) ID of the list."
+          },
+          "public_id": {
+            "type": "integer",
             "description": "The ID of the list."
           },
           "title": {
@@ -1696,7 +1700,8 @@
         },
         "example": {
           "@type": "list",
-          "id": "1234",
+          "id": "21f55a266d69",
+          "public_id": 1234,
           "title": "Title of the list",
           "description": "Description of the list",
           "status": "READY",


### PR DESCRIPTION
# Description

Update documentation showing the new `public_id` field. Small change to example to be more representative of response (`id` field represents our hashed value)

# Tasks
  - [ ] Added correct pull request label (work in progress, DO NOT MERGE, ready for review) etc
  - [ ] Relevant reviewers have been added to this issue
  - [ ] Added sufficient test coverage where needed
  - [ ] Created an ADR for change if appropriate
  - [ ] Add intended additional tasks here and track your progress

# Deployment notes

*Will this change affect any other components? 
Who should be aware of this change? 
When shoulld you deploy the change? 
how are you going to avoid any service impact?*
