### PR TITLE
Add GET parameter request_id to push errors endpoint

### DIFF
--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -1114,6 +1114,17 @@
         ],
         "summary": "List errors",
         "description": "Return a list of the 100 latest push record errors",
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "query",
+            "description": "Identifier of the request.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "List of Errors object",


### PR DESCRIPTION
# Description

Add an optional query parameter to the push errors endpoint: request_id.

# Tasks
  - [ ] Added correct pull request label (work in progress, DO NOT MERGE, ready for review) etc
  - [ ] Relevant reviewers have been added to this issue
  - [ ] Added sufficient test coverage where needed
  - [ ] Created an ADR for change if appropriate
  - [ ] Add intended additional tasks here and track your progress

# Deployment notes

*Will this change affect any other components? 
Who should be aware of this change? 
When shoulld you deploy the change? 
how are you going to avoid any service impact?*
