### PR TITLE
add email in path

### DIFF
--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -754,7 +754,7 @@
         }
       }
     },
-    "/profiles": {
+    "/profiles/{email}": {
       "get": {
         "tags": [
           "Profiles"


### PR DESCRIPTION
In a previous task while updating the docs email from the path was removed and it has caused a conflict in swagger file impacting the documentation availability for get-profiles endpoint, adding the path to temporarily mitigate the issue