### PR TITLE
Increase custom event propert string lenght to 512

### DIFF
--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -1893,7 +1893,7 @@
         "properties": {
           "string_custom_field": {
             "type": "string",
-            "description": "Any characters permitted, including accents and other character symbols.\nString fields have a 64 character limit."
+            "description": "Any characters permitted, including accents and other character symbols.\nString fields have a 512 character limit."
           },
           "boolean_custom_field": {
             "type": "boolean",


### PR DESCRIPTION
This field is not actually enforced in the backend but the small length was hindering some use cases. I'll keep the lie on the docs to prevent any abuses by design.

