### PR TITLE
Add orders by customer filters

### DIFF
--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -203,6 +203,24 @@
             }
           },
           {
+            "name": "customer_id",
+            "in": "query",
+            "description": "Find all orders by customer.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "email",
+            "in": "query",
+            "description": "Find all orders by customer.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "updateBefore",
             "in": "query",
             "description": "Find all orders updated before a certain date.",


### PR DESCRIPTION
Allows to filter orders by customer_id (their_id) and email. If the filters match more than one customer it will raise a 409 Conflict

