### PR TITLE
BIGDATA - Update Push API phone_number description

### DIFF
--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -1693,7 +1693,7 @@
           },
           "phone_number": {
             "type": "string",
-            "description": "The contact's mobile phone number, in E.164/International format (e.g. starting \"+447...\")"
+            "description": "The contact's mobile phone number, in E.164/International format (e.g. starting \"+447...\") or National format (without the country code prefix, please note that country_id is required in order to validate the phone number in this format)."
           },
           "marketing_optin": {
             "type": "string",


### PR DESCRIPTION
It is now possible to push contact records with phone numbers in national format. It is required to also provide the country_id field when passing phone numbers in national format (in order to parse and validate the phone number).

# Description

*Include a brief description about your intended change.*

# Tasks
  - [x] Added correct pull request label (work in progress, DO NOT MERGE, ready for review) etc
  - [x] Relevant reviewers have been added to this issue
  - [ ] Added sufficient test coverage where needed
  - [ ] Created an ADR for change if appropriate
  - [ ] Add intended additional tasks here and track your progress

# Deployment notes

*Will this change affect any other components? 
Who should be aware of this change? 
When should you deploy the change? 
how are you going to avoid any service impact?*
