### PR TITLE
Add API docs for translation requests

### DIFF
--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -5027,7 +5027,6 @@
             "title": "Status",
             "description": "The current status of the translation request.",
             "enum": [
-                "created",
                 "pending",
                 "cancelled",
                 "completed"

--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -2046,7 +2046,7 @@
           }
         ],
         "security": [
-          {"apiKeyWithTranslationReadScope": []}
+          {"apiKeyReadTranslations": []}
         ],
         "responses": {
           "200": {
@@ -2092,7 +2092,7 @@
           }
         ],
         "security": [
-          {"apiKeyWithTranslationReadScope": []}
+          {"apiKeyReadTranslations": []}
         ],
         "responses": {
           "200": {
@@ -2135,7 +2135,7 @@
           }
         ],
         "security": [
-          {"apiKeyWithTranslationReadScope": []}
+          {"apiKeyReadTranslations": []}
         ],
         "responses": {
           "200": {
@@ -2167,7 +2167,7 @@
         ],
         "summary": "Submit a translation for a pending translation request.",
         "security": [
-          {"apiKeyWithTranslationWriteScope": []}
+          {"apiKeyWriteTranslations": []}
         ],
         "requestBody": {
           "content": {
@@ -2239,13 +2239,13 @@
         "in": "header",
         "description": "Ometria API key which can be obtained from your Ometria account administrator"
       },
-      "apiKeyWithTranslationReadScope": {
+      "apiKeyReadTranslations": {
         "type": "apiKey",
         "name": "X-Ometria-Auth",
         "in": "header",
         "description": "Ometria API key which can be obtained from your Ometria account administrator. **Note**: The API-Key must have the scope `read:translations`."
       },
-      "apiKeyWithTranslationWriteScope": {
+      "apiKeyWriteTranslations": {
         "type": "apiKey",
         "name": "X-Ometria-Auth",
         "in": "header",

--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -1997,7 +1997,6 @@
               "items": {
                   "type": "string",
                   "enum": [
-                      "created",
                       "pending",
                       "cancelled",
                       "completed"
@@ -4923,7 +4922,6 @@
             "title": "Status",
             "description": "The current status of the translation request.",
             "enum": [
-                "created",
                 "pending",
                 "cancelled",
                 "completed"
@@ -5012,6 +5010,11 @@
       },
       "TranslationSubmit": {
         "properties": {
+          "request_id": {
+            "type": "integer",
+            "title": "Request ID",
+            "description": "The ID of the translation request."
+          },
           "language": {
             "type": "string",
             "title": "Language",

--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -2170,7 +2170,22 @@
         },
         "responses": {
           "200": {
-            "description": "Translation submitted successfully."
+            "description": "Translation submitted successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "message": "Translations submitted"
+                }
+              }
+            }
           },
           "400": {
             "description": "Invalid request."

--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -2045,6 +2045,9 @@
             }
           }
         ],
+        "security": [
+          {"apiKeyWithTranslationReadScope": []}
+        ],
         "responses": {
           "200": {
             "description": "List of translation requests.",
@@ -2088,6 +2091,9 @@
             }
           }
         ],
+        "security": [
+          {"apiKeyWithTranslationReadScope": []}
+        ],
         "responses": {
           "200": {
             "description": "Translation request details.",
@@ -2128,6 +2134,9 @@
             }
           }
         ],
+        "security": [
+          {"apiKeyWithTranslationReadScope": []}
+        ],
         "responses": {
           "200": {
             "description": "Translation request details.",
@@ -2157,6 +2166,9 @@
           "Translation Requests"
         ],
         "summary": "Submit a translation for a pending translation request.",
+        "security": [
+          {"apiKeyWithTranslationWriteScope": []}
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -2226,6 +2238,18 @@
         "name": "X-Ometria-Auth",
         "in": "header",
         "description": "Ometria API key which can be obtained from your Ometria account administrator"
+      },
+      "apiKeyWithTranslationReadScope": {
+        "type": "apiKey",
+        "name": "X-Ometria-Auth",
+        "in": "header",
+        "description": "Ometria API key which can be obtained from your Ometria account administrator. **Note**: The API-Key must have the scope `read:translations`."
+      },
+      "apiKeyWithTranslationWriteScope": {
+        "type": "apiKey",
+        "name": "X-Ometria-Auth",
+        "in": "header",
+        "description": "Ometria API key which can be obtained from your Ometria account administrator. **Note**: The API-Key must have the scope `write:translations`."
       }
     },
     "schemas": {

--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -2111,6 +2111,46 @@
         }
       }
     },
+    "/translations/requests/{request_id}/preview": {
+      "get": {
+        "tags": [
+          "Translation Requests"
+        ],
+        "summary": "Get translation request template preview in source language.",
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "description": "The id of the translation request.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Translation request details.",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "API key is not authorised to access this resource."
+          },
+          "404": {
+            "description": "Translation request not found."
+          },
+          "500": {
+            "description": "An error occurred."
+          }
+        }
+      }
+    },
     "/translations/submit": {
       "post": {
         "tags": [

--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -2243,13 +2243,13 @@
         "type": "apiKey",
         "name": "X-Ometria-Auth",
         "in": "header",
-        "description": "Ometria API key which can be obtained from your Ometria account administrator. **Note**: The API-Key must have the scope `read:translations`."
+        "description": "Ometria API key which can be obtained from your Ometria account administrator. **Note**: The API key must have the scope `read:translations`."
       },
       "apiKeyWriteTranslations": {
         "type": "apiKey",
         "name": "X-Ometria-Auth",
         "in": "header",
-        "description": "Ometria API key which can be obtained from your Ometria account administrator. **Note**: The API-Key must have the scope `write:translations`."
+        "description": "Ometria API key which can be obtained from your Ometria account administrator. **Note**: The API key must have the scope `write:translations`."
       }
     },
     "schemas": {

--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -1970,6 +1970,184 @@
           }
         }
       }
+    },
+    "/translations/requests": {
+      "get": {
+        "tags": [
+          "Translation Requests"
+        ],
+        "summary": "List translation requests.",
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "query",
+            "required": false,
+            "description": "The id of the translation request.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Get translation requests that has one of the following statuses.",
+            "schema": {
+              "type": "array",
+              "items": {
+                  "type": "string",
+                  "enum": [
+                      "created",
+                      "pending",
+                      "cancelled",
+                      "completed"
+                  ]
+              }
+            }
+          },
+          {
+            "name": "since_created",
+            "in": "query",
+            "required": false,
+            "description": "Get translation requests created since this timestamp, in ISO 8601 format.",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "since_updated",
+            "in": "query",
+            "required": false,
+            "description": "Get translation requests updated since this timestamp, in ISO 8601 format.",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "The number of records to fetch. Maximum 50.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "The index of the first record to fetch.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of translation requests.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TranslationRequest"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request."
+          },
+          "403": {
+            "description": "API key is not authorised to access this resource."
+          },
+          "500": {
+            "description": "An error occurred."
+          }
+        }
+      }
+    },
+    "/translations/requests/{request_id}": {
+      "get": {
+        "tags": [
+          "Translation Requests"
+        ],
+        "summary": "Get translation request details.",
+        "parameters": [
+          {
+            "name": "request_id",
+            "in": "path",
+            "required": true,
+            "description": "The id of the translation request.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Translation request details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TranslationRequestDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "API key is not authorised to access this resource."
+          },
+          "404": {
+            "description": "Translation request not found."
+          },
+          "500": {
+            "description": "An error occurred."
+          }
+        }
+      }
+    },
+    "/translations/submit": {
+      "post": {
+        "tags": [
+          "Translation Requests"
+        ],
+        "summary": "Submit a translation for a pending translation request.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TranslationSubmit"
+              }
+            }
+          },
+          "description": "Translation for the pending translation request.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Translation submitted successfully."
+          },
+          "400": {
+            "description": "Invalid request."
+          },
+          "403": {
+            "description": "API key is not authorised to access this resource."
+          },
+          "404": {
+            "description": "Translation request not found."
+          },
+          "500": {
+            "description": "An error occurred."
+          }
+        }
+
+      }
     }
   },
   "security": [
@@ -4710,6 +4888,148 @@
           "detail"
         ],
         "title": "ErrorResponse"
+      },
+      "TranslationRequest": {
+        "properties": {
+          "request_id": {
+              "type": "string",
+              "title": "Request ID",
+              "description": "The ID of the translation request."
+          },
+          "source_lang": {
+            "type": "string",
+            "title": "Source Language",
+            "description": "The language code of the translation source language."
+          },
+          "target_lang": {
+            "type": "string",
+            "title": "Target Language",
+            "description": "The language code of the translation target language."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created Timestamp",
+            "description": "The date and time the translation request was created."
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated Timestamp",
+            "description": "The date and time the translation request was last updated."
+          },
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "description": "The current status of the translation request.",
+            "enum": [
+                "created",
+                "pending",
+                "cancelled",
+                "completed"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "request_id",
+          "source_lang",
+          "target_lang",
+          "created_at",
+          "updated_at",
+          "status"
+        ],
+        "title": "TranslationRequest"
+      },
+      "TranslationRequestDetails": {
+        "properties": {
+          "source_lang": {
+            "type": "string",
+            "title": "Source Language",
+            "description": "The language code of the translation source language."
+          },
+          "target_lang": {
+            "type": "string",
+            "title": "Target Language",
+            "description": "The language code of the translation target language."
+          },
+          "source_translations": {
+            "type": "object",
+            "title": "Source Translations",
+            "description": "The source language translations."
+          },
+          "target_translations": {
+            "type": "object",
+            "title": "Target Translations",
+            "description": "The target language translations."
+          },
+          "translation_tags": {
+            "type": "array",
+              "items": {
+                  "type": "string"
+              },
+            "title": "Translation Tags",
+            "description": "The tags that are requested for translation from source to target language."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created Timestamp",
+            "description": "The date and time the translation request was created."
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated Timestamp",
+            "description": "The date and time the translation request was last updated."
+          },
+          "status": {
+            "type": "string",
+            "title": "Status",
+            "description": "The current status of the translation request.",
+            "enum": [
+                "created",
+                "pending",
+                "cancelled",
+                "completed"
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "source_lang",
+          "target_lang",
+          "source_translations",
+          "target_translations",
+          "translation_tags",
+          "created_at",
+          "updated_at",
+          "status"
+        ],
+        "title": "TranslationRequestDetails"
+      },
+      "TranslationSubmit": {
+        "properties": {
+          "language": {
+            "type": "string",
+            "title": "Language",
+            "description": "The language code of submitted translations."
+          },
+          "translations": {
+            "type": "object",
+            "title": "Translations",
+            "description": "Submitted translations."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": [
+          "language",
+          "translations"
+        ],
+        "title": "TranslationSubmit"
       }
     }
   },


### PR DESCRIPTION
* Add API docs for translation request endpoints:
- GET /translations/requests
- GET /translations/requests/{id}
- GET /translations/requests/{id}/preview
- POST /translations/submit
* Added new security schemes with API scope information

