### PR TITLE
Add OrderExtended schema to Push API anyOf

### DIFF
--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -36,6 +36,9 @@
                       "$ref": "#/components/schemas/Order"
                     },
                     {
+                      "$ref": "#/components/schemas/OrderExtended"
+                    },
+                    {
                       "$ref": "#/components/schemas/Product"
                     }
                   ]


### PR DESCRIPTION
## Summary
- The `OrderExtended` schema was defined in `components/schemas` but not referenced from any API path, so readme.io did not render it in the public docs.
- The "Order currency" article instructs integrators to use `OrderExtended` for multi-currency orders, but the schema itself was not visible to them.
- This PR adds an `$ref` to `OrderExtended` in the `/push` request body `anyOf`, alongside the basic `Order`, so the schema gets rendered in the public docs.

## Test plan
- [ ] Verify the swagger.json still parses as valid JSON
- [ ] Confirm `OrderExtended` shows up in the rendered readme.io docs after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)