### PR TITLE
Add title fields to OrderExtended schemas

### DIFF
--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -3199,6 +3199,7 @@
         }
       },
       "OrderExtended": {
+        "title": "Order Extended",
         "type": "object",
         "description": "Describes an Order record.",
         "required": [
@@ -3455,6 +3456,7 @@
         }
       },
       "OrderExtendedTotals": {
+        "title": "Order Extended Totals",
         "type": "object",
         "description": "The totals of the order in a base currency and a local currency.",
         "properties": {
@@ -3483,6 +3485,7 @@
         }
       },
       "OrderExtendedLocalTotal": {
+        "title": "Order Extended Local Total",
         "type": "object",
         "description": "The totals of this order represented in the local currency",
         "required": [
@@ -3531,6 +3534,7 @@
         }
       },
       "OrderExtendedBaseTotal": {
+        "title": "Order Extended Base Total",
         "type": "object",
         "description": "The totals of this order represented in the base currency",
         "required": [
@@ -3579,6 +3583,7 @@
         }
       },
       "OrderExtendedLineItemTotals": {
+        "title": "Order Extended Line Item Totals",
         "type": "object",
         "description": "The totals of the lineitem. This can be used to express the order value in a base currency and a local currency.",
         "properties": {
@@ -3605,6 +3610,7 @@
         }
       },
       "OrderExtendedLineItemLocalTotal": {
+        "title": "Order Extended Line Item Local Total",
         "type": "object",
         "description": "The totals of this lineitem represented in the local currency",
         "required": [
@@ -3658,6 +3664,7 @@
         }
       },
       "OrderExtendedLineItemBaseTotal": {
+        "title": "Order Extended Line Item Base Total",
         "type": "object",
         "description": "The totals of this lineitem represented in the base currency",
         "required": [


### PR DESCRIPTION
## Summary
- Without an explicit `title`, ReadMe falls back to the schema key name rendered in uppercase (e.g. `ORDEREXTENDED`).
- Adding human-readable titles for the `OrderExtended` schema and its 6 sub-schemas: totals, local/base totals, line item totals, line item local/base totals.

## Test plan
- [ ] Confirm schemas now render as "Order Extended", "Order Extended Totals", etc. in https://docs.ometria.com/

🤖 Generated with [Claude Code](https://claude.com/claude-code)