### PR TITLE
Revert titles on OrderExtended sub-schemas

### DIFF
--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -3199,6 +3199,7 @@
         }
       },
       "OrderExtended": {
+        "title": "Order Extended",
         "type": "object",
         "description": "Describes an Order record.",
         "required": [
@@ -3455,6 +3456,7 @@
         }
       },
       "OrderExtendedTotals": {
+        "title": "Order Extended Totals",
         "type": "object",
         "description": "The totals of the order in a base currency and a local currency.",
         "properties": {
@@ -3483,6 +3485,7 @@
         }
       },
       "OrderExtendedLocalTotal": {
+        "title": "Order Extended Local Total",
         "type": "object",
         "description": "The totals of this order represented in the local currency",
         "required": [
@@ -3531,6 +3534,7 @@
         }
       },
       "OrderExtendedBaseTotal": {
+        "title": "Order Extended Base Total",
         "type": "object",
         "description": "The totals of this order represented in the base currency",
         "required": [
@@ -3579,6 +3583,7 @@
         }
       },
       "OrderExtendedLineItemTotals": {
+        "title": "Order Extended Line Item Totals",
         "type": "object",
         "description": "The totals of the lineitem. This can be used to express the order value in a base currency and a local currency.",
         "properties": {
@@ -3605,6 +3610,7 @@
         }
       },
       "OrderExtendedLineItemLocalTotal": {
+        "title": "Order Extended Line Item Local Total",
         "type": "object",
         "description": "The totals of this lineitem represented in the local currency",
         "required": [
@@ -3658,6 +3664,7 @@
         }
       },
       "OrderExtendedLineItemBaseTotal": {
+        "title": "Order Extended Line Item Base Total",
         "type": "object",
         "description": "The totals of this lineitem represented in the base currency",
         "required": [

--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -3456,7 +3456,6 @@
         }
       },
       "OrderExtendedTotals": {
-        "title": "Order Extended Totals",
         "type": "object",
         "description": "The totals of the order in a base currency and a local currency.",
         "properties": {
@@ -3485,7 +3484,6 @@
         }
       },
       "OrderExtendedLocalTotal": {
-        "title": "Order Extended Local Total",
         "type": "object",
         "description": "The totals of this order represented in the local currency",
         "required": [
@@ -3534,7 +3532,6 @@
         }
       },
       "OrderExtendedBaseTotal": {
-        "title": "Order Extended Base Total",
         "type": "object",
         "description": "The totals of this order represented in the base currency",
         "required": [
@@ -3583,7 +3580,6 @@
         }
       },
       "OrderExtendedLineItemTotals": {
-        "title": "Order Extended Line Item Totals",
         "type": "object",
         "description": "The totals of the lineitem. This can be used to express the order value in a base currency and a local currency.",
         "properties": {
@@ -3610,7 +3606,6 @@
         }
       },
       "OrderExtendedLineItemLocalTotal": {
-        "title": "Order Extended Line Item Local Total",
         "type": "object",
         "description": "The totals of this lineitem represented in the local currency",
         "required": [
@@ -3664,7 +3659,6 @@
         }
       },
       "OrderExtendedLineItemBaseTotal": {
-        "title": "Order Extended Line Item Base Total",
         "type": "object",
         "description": "The totals of this lineitem represented in the base currency",
         "required": [


### PR DESCRIPTION
## Summary
- The sub-schema titles added in #61 ("Order Extended Line Item Local Total" etc.) are too long and not necessary.
- Keeping only the parent `OrderExtended` title, which was the only one that was incorrect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)