### PR TITLE
Add 'list of product ids' type to CustomFieldType enum

### DIFF
--- a/assets/api-swagger/swagger.json
+++ b/assets/api-swagger/swagger.json
@@ -4746,7 +4746,8 @@
           "decimal",
           "date",
           "blob",
-          "list of string"
+          "list of string",
+          "list of product ids"
         ],
         "title": "CustomFieldType"
       },


### PR DESCRIPTION
### Summary
Adds the missing `"list of product ids"` value to the `CustomFieldType` enum in `assets/api-swagger/swagger.json`.

### Why
The `list of product ids` type is supported by the backend on `POST /custom_fields`, but it was missing from the OpenAPI spec — so it wasn't listed as a valid `type` in the public API docs.

### Diff
```diff
 "CustomFieldType": {
   "type": "string",
   "enum": [
     "string",
     "integer",
     "decimal",
     "date",
     "blob",
-    "list of string"
+    "list of string",
+    "list of product ids"
   ]
 }
```

### Impact
Covers `POST /custom_fields`, the `GET /custom_fields` `type` filter, and `CustomFieldResponse.type` in one change.